### PR TITLE
Fix race condition on lazy constructor resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -2121,13 +2121,13 @@ function Runtime() {
 
         const type = typeof v;
         if (type === 'string') {
-            if (cachedNSString === null) {
+            if (cachedNSStringCtor === null) {
                 cachedNSString = classRegistry.NSString;
                 cachedNSStringCtor = cachedNSString.stringWithUTF8String_;
             }
             return cachedNSStringCtor.call(cachedNSString, Memory.allocUtf8String(v));
         } else if (type === 'number') {
-            if (cachedNSNumber === null) {
+            if (cachedNSNumberCtor === null) {
                 cachedNSNumber = classRegistry.NSNumber;
                 cachedNSNumberCtor = cachedNSNumber.numberWithDouble_;
             }


### PR DESCRIPTION
To resolve cached NSString and NSNumber constructors, the cached class was checked for being `null`,
not the constructor itself. This made possible for two racing threads to cause a `call` on a null function,
if the first gets preempted before assigning the value to the constructor variable, but after setting the
cached class variable.

Checking instead for the constructor variable avoids the possibility of calling a null function.
The performance cost of this is that both the competing threads will resolve the constructor,
but the impact is limited in time (until the resolution happens once).