### PR TITLE
Fix cached methods lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -688,7 +688,8 @@ function Runtime() {
 
             method = cachedMethods[fullName];
             if (method !== undefined) {
-              return method;
+                cachedMethods[rawName] = method;
+                return method;
             }
 
             const kind = tokens[0];

--- a/index.js
+++ b/index.js
@@ -684,10 +684,16 @@ function Runtime() {
                 return method;
 
             const tokens = parseMethodName(rawName);
+            const fullName = tokens[2];
+
+            method = cachedMethods[fullName];
+            if (method !== undefined) {
+              return method;
+            }
+
             const kind = tokens[0];
             const name = tokens[1];
             const sel = selector(name);
-            const fullName = tokens[2];
             const defaultKind = isClass() ? '+' : '-';
 
             if (protocol) {
@@ -747,6 +753,7 @@ function Runtime() {
             }
 
             cachedMethods[fullName] = method;
+            cachedMethods[rawName] = method;
             if (kind === defaultKind)
                 cachedMethods[jsMethodName(name)] = method;
 


### PR DESCRIPTION
Avoid cache false misses when looking up methods with spaces like
`- viewDidLoad` vs `-viewDidLoad`