### PR TITLE
Handle Symbol keys in the get trap for the latest duktape.

### DIFF
--- a/index.js
+++ b/index.js
@@ -567,6 +567,9 @@ function Runtime() {
                         }
                         return cachedIvars;
                     default:
+                        if (typeof property === "symbol") {
+                            return target[property];
+                        }
                         if (protocol) {
                             const details = findProtocolMethod(property);
                             if (details === null || !details.implemented)


### PR DESCRIPTION
With the runtime upgrades in Frida 12.1, scripts that used objects with a string representation suddenly started complaining with errors such as:

```
TypeError: cannot string coerce Symbol
```

This would be the a reproducible case for Frida 12.1.0 and a simple script such as:

```javascript
var NSString = ObjC.classes.NSString;
var nsstring = NSString.stringWithString_("foo");
console.log(nsstring);
```

After some discussions with @mrmacete via Telegram, I managed to get scripts behaving normally again after patching with the following, pretty dirty patch: 

```diff
diff --git a/index.js b/index.js
index a4e956a..bf5ec57 100644
--- a/index.js
+++ b/index.js
@@ -435,6 +435,10 @@ function Runtime() {
                 return hasProperty(property);
             },
             get(target, property, receiver) {
+                if (typeof property === 'symbol') {
+                    property = 'toString';
+                }
+
                 switch (property) {
                     case "handle":
                         return handle;
```

Since then, @mrmacete created an [issue](https://github.com/svaarala/duktape/issues/1968) over at duktape about the use of `Symbol()` forming part of the `get()` trap in a `Proxy` object. [This comment](https://github.com/svaarala/duktape/issues/1968#issuecomment-417368257) suggested an alternative fix which this PR implements.

I have tested a number of scripts that would previously fail but work ok with this patch.

Some sample test runs:

```javascript
'use strict';

const ObjC = require('frida-objc');

var example = () => {
    let NSString = ObjC.classes.NSString;
    let nsstring = NSString.stringWithString_("foo");
    console.log(nsstring);
}

global.run = function () {
    try {
        example();
    } catch (err) {
        console.log(err.stack);
    }
};
```

With unpatched frida-objc:

```bash
$ frida -q --enable-jit -R -n Gadget -l _agent.js -e "run();"
TypeError: cannot string coerce Symbol
    at f (frida/node_modules/frida-objc/index.js:866)
    at l (frida/node_modules/frida-objc/index.js:711)
    at p (frida/node_modules/frida-objc/index.js:841)
    at frida/node_modules/frida-objc/index.js:575
    at join (native)
    at o (frida/runtime/console.js:25)
    at frida/runtime/console.js:10
    at example (/repl1.js:10)
    at /repl1.js:16
    [...]
undefined

Thank you for using Frida!
```

With patched frida-objc:

```bash
$ frida -q --enable-jit -R -n Gadget -l _agent.js -e "run();"
foo
undefined

Thank you for using Frida!
```