### PR TITLE
Bail out if a method has no target

### DIFF
--- a/index.js
+++ b/index.js
@@ -756,7 +756,11 @@ function Runtime() {
                         const forwardingTarget = self.forwardingTargetForSelector_(sel);
                         if (forwardingTarget !== null && forwardingTarget.$kind === 'instance') {
                             target = forwardingTarget;
+                        } else {
+                            return null;
                         }
+                    } else {
+                        return null;
                     }
 
                     if ("- methodSignatureForSelector:" in target) {


### PR DESCRIPTION
In this way we avoid to wrap and expose methods for which ultimately we’re not able to find an implementation. So that calling a method wrapper shouldn’t result in an “unrecognized selector” exception even in weird cases.