### PR TITLE
fix for readType()

### DIFF
--- a/index.js
+++ b/index.js
@@ -2162,7 +2162,7 @@ function Runtime() {
         } else if (id === '(') {
             readUntil('=', cursor);
             const unionFields = [];
-            while (peekChar(cursor) !== '}')
+            while (peekChar(cursor) !== ')')
                 unionFields.push(readType(cursor));
             skipChar(cursor); // ')'
             return unionType(unionFields);


### PR DESCRIPTION
mis-match of '}' and ')' characters lead to "Unable to handle type )" error.
Fixes #4 